### PR TITLE
Feature/djangoplicity migration

### DIFF
--- a/hubble/settings/common.py
+++ b/hubble/settings/common.py
@@ -20,10 +20,6 @@ from celery.schedules import crontab
 # load the settings resulting in a ImproperlyConfigured error
 ugettext = lambda s: s
 
-
-import djangoplicity.crosslinks
-from djangoplicity.contentserver import CDN77ContentServer
-
 #############################
 # ENVIRONMENT CONFIGURATION #
 #############################
@@ -495,8 +491,6 @@ ARCHIVE_WORKFLOWS = {
 }
 
 VIDEO_RENAME_NOTIFY = [HUBBLE_DEFAULT_EMAIL, 'hubbleesa@gmail.com']
-
-ARCHIVE_CROSSLINKS = djangoplicity.crosslinks.crosslinks_for_domain('esahubble.org')
 
 
 # CONTACTS APP

--- a/private-requirements.txt
+++ b/private-requirements.txt
@@ -1,7 +1,7 @@
 # Last update: fix video rename feature
-git+https://github.com/djangoplicity/djangoplicity-actions.git@release/python3
-git+https://github.com/djangoplicity/djangoplicity-customsearch.git@release/python3
-git+https://github.com/djangoplicity/djangoplicity-newsletters.git@newsletters-esahubble
-git+https://github.com/djangoplicity/djangoplicity-products2@Feature/video-conference-background-product
-git+https://github.com/djangoplicity/djangoplicity@djangoplicity-esahubble
-git+https://github.com/djangoplicity/djangoplicity-contacts@contacts-esahubble
+git+https://github.com/esawebb-hubble/djangoplicity.git@main
+git+https://github.com/esawebb-hubble/djangoplicity-actions.git@main
+git+https://github.com/esawebb-hubble/djangoplicity-customsearch.git@main
+git+https://github.com/esawebb-hubble/djangoplicity-newsletters.git@main
+git+https://github.com/esawebb-hubble/djangoplicity-products2.git@main
+git+https://github.com/esawebb-hubble/djangoplicity-contacts.git@main

--- a/scripts/command-dev.sh
+++ b/scripts/command-dev.sh
@@ -3,6 +3,7 @@
 # Copy test media that will provide extra coverage for templates
 /bin/cp -rf test-utils/media/* docs/static
 
+python manage.py makemigrations
 python manage.py migrate
 python manage.py loaddata initial dev
 python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
- We replaced the old djangoplicity repositories with new instances in an ESA organization on github
- We removed the cross-links modiel because it is not used as the website is no longer monitored by ESO.